### PR TITLE
traslated: hackathon-projects.adoc 1

### DIFF
--- a/modules/samples/pages/hackathon-projects.adoc
+++ b/modules/samples/pages/hackathon-projects.adoc
@@ -1,3 +1,56 @@
+= ハッカソン プロジェクト
+:description: Quick links to example code for common use-cases for your dapp
+:keywords: Internet Computer,blockchain,cryptocurrency,ICP tokens,smart contracts,cycles,wallet,software canister,developer onboarding,dapp,example,code,rust,Motoko
+:proglang: Motoko
+:IC: Internet Computer
+:company-id: DFINITY
+ifdef::env-github,env-browser[:outfilesuffix:.adoc]
+
+世界中の開発者がハッカソンに参加し Dapp やツールなど様々なプロジェクトを Internet Computer  上で構築しています。触発されるべく優勝したプロジェクトのいくつかのソースコードをご覧ください。
+
+[[dfinihack]]
+== DFINIHack
+
+ハッカソンは優れた学びの方法です。DFINITYでは外部のハッカソンに加え、社内のハッカソンも開催しています。コーディング経験の有無に関わらず、どんな分野からでも誰でも参加できます。目的は新しいユースケースの探索、開発者に提供するドキュメントやツールの評価、そしてビルダー文化を内部に浸透させることです。
+
+=== Sidekick
+Sidekick は、数行のコードで Canister スマートコントラクトを構築できる Internet Computer 上で動作する Dapp です。
+
+- https://github.com/blynn/sidekick[ GitHub のコードはこちら]
+- https://ffgig-jyaaa-aaaae-aaaoa-cai.raw.ic0.app[ Canister ライブ]
+
+=== IC Vault
+IC Vault はエンドツゥエンドの暗号化（ 言い換えると Internet Computer 内部で平文を見ることができない）により、Internet Computer を経由したデバイス間のデータの安全な同期を保証します。
+
+- https://github.com/timohanke/hack13[ GitHub のコードはこちら]
+- https://xggrc-cyaaa-aaaaj-aaasq-cai.raw.ic0.app[ Canister ライブ]
+- https://youtu.be/16xxA8EKEhE[ YouTube のプレゼンテーション]
+
+=== PrivIC
+PrivIC（「プライバシー」と発音します）は、 Internet Computer 上での ID 管理を提供します。ユーザーは、名前、生年月日、Eメール、電話番号などの属性からなる自分の ID を管理するため、直接 PrivIC アプリにアクセスするか、アプリの登録・サインイン機能で利用することができます。
+
+- https://github.com/open-ic/priv-ic[ GitHub のコードはこちら]
+
+=== DeFind
+DeFind はステーキングベースの検索エンジンです。インターネットが普及した今日、検索エンジンはウェブクローラーを使ってデータを非公開のアルゴリズムに送り込んでいます。広告主にとって、これは間違ったインセンティブになります。例えば、見えないテキストでウェブクローラーを騙したり、ボットを通じて偽のトラフィックを発生させたりするインセンティブが働くかもしれません。
+
+- https://github.com/IC-Search/ic-search[ GitHub のコードはこちら]
+- https://jbioa-siaaa-aaaai-qanfq-cai.ic0.app[ Canister ライブ]
+
+=== IC Notary
+IC Notary はある時点の文書（または任意のファイル）を保有していたことを証明できるタイムスタンプ付き公証サービスです。ユーザーはファイルを IC Notary にアップロードすることができ、また過去にアップロードされたファイルを検索・ダウンロードすることもできます。
+
+- https://github.com/jplevyak/dfnhack7[ GitHub のコードはこちら]
+- https://jbxh5-eqaaa-aaaae-qaaoq-cai.ic0.app[ Canister ライブ]
+
+=== IC Netboot
+IC Netboot は開発者が Canister から直接、仮想マシン（VM）を起動できるようにし、起動インフラの分散化と冗長化をします。さらに、zookeeper のようなアプリケーションのVMデータの予備になりえます。最後にTFTP/DHCP/iPXE のような合法的なプロトコルで Internet Computer と会話するためのコンセプトの証明となります。
+
+- https://github.com/farazshaikh/team14[ GitHub のコードはこちら]
+
+
+
+////
 = Hackathon Projects
 :description: Quick links to example code for common use-cases for your dapp
 :keywords: Internet Computer,blockchain,cryptocurrency,ICP tokens,smart contracts,cycles,wallet,software canister,developer onboarding,dapp,example,code,rust,Motoko
@@ -49,6 +102,8 @@ IC Netboot allows developers to boot a virtual machine (VM) directly from a cani
 - https://github.com/farazshaikh/team14[See code on GitHub]
 
 
+
+////
 
 
 


### PR DESCRIPTION
### modules/samples/pages/hackathon-projects.adocを翻訳しました。

##### 改善したい点

* 9行目、「触発されるべく」が適切か？  原文 "Get inspired"
* 11行目、「DFINIHACK」をそのまま英語表記にしたが他に訳せるか？
* 14行目、「ビルダー文化」が適切か？　原文"and to promote a builder’s culture internally"
* 23行目、「安全な同期」が適切か？　原文"IC Vault ensures the secure synchronization of data "
* 23行目、「言い換えると」が適切か？英文 i.eでもよいかも　原文"(i.e., the Internet Computer cannot see any cleartext)"
* 35行目、「非公開」が適切か？　原文"With the internet today, search engines use web crawlers to feed data into secret algorithms."
* 47行目、「分散化と冗長化」が適切か？　少し意訳すぎたかも？　原文"making the boot infrastructure decentralized and unstoppable."
* すべてのプロダクトモードのリンク、「Canister ライブ」が適切か？　原文"Live Canister"

以上になります。
