### PR TITLE
Modules/samples/pages/dex.adoc

### DIFF
--- a/modules/samples/pages/dex.adoc
+++ b/modules/samples/pages/dex.adoc
@@ -1,3 +1,96 @@
+# DEX サンプル
+
+IC 上で DEFI アプリケーションを実現するためには、DEFI の Canister は token Canister や ledger Canister と相互に対話する必要があります。このサンプル Dapp ではこれらの相互対話を用意にする方法を説明します。
+
+サンプルのDEFIは https://github.com/dfinity/examples/tree/master/motoko/defi[Motoko] と https://github.com/dfinity/examples/tree/master/rust/defi[Rust] で実装されており、 https://gzz56-daaaa-aaaal-qai2a-cai.ic0.app/[ IC 上のここで動作中] を見ることが出来ます。
+
+## アーキテクチャ
+
+IC の設計ではより複雑なオンチェーン演算処理が可能です。汎用ストレージと組み合わせれば、オンチェーンでのオーダーブックも可能です。このサンプルコードではこれらの機能を利用して、ユーザーの残高と注文を取引所 Canister に保存します。サンプルの取引所機能は以下のステップに要約することが出来ます。
+
+* 取引所が資金の保管（ ICP と他のトークンでは仕組みが異なる、後述）。
+* 取引所が内部バランスブックを更新する。
+* ユーザーは取引所で取引を行い、取引所は内部バランスブックを更新する。
+* 取引所から資金を引き出すと、保管されていた資金はユーザーに戻される。
+
+### インターフェイス
+
+取引所からユーザー固有の元帳アカウント識別子をリクエストします。この一意のアカウント識別子は、取引所の元帳アカウントのユーザー固有のサブアカウントを表し、ユーザーのデポジットを区別できるようにします。
+
+```candid
+getDepositAddress: () -> (blob);
+```
+
+取引所へのユーザーのデポジットを開始します。ユーザーが ICP をデポジットしたい場合、取引所はユーザー固有のデポジットアドレスからそのデフォルトのサブアドレスに資金を移動し、DEX でユーザーの ICP 残高を調整します。ユーザーが DIP トークンのデポジットを希望している場合、取引所は承認された資金をそのトークン口座に移動しようとし、ユーザーの残高を調整します。
+
+```candid
+deposit: (Token) -> (DepositReceipt);
+```
+
+取引所へ出金依頼をします。取引所はユーザーが十分な残高を持っている場合、ユーザーに資金を送り返します。
+
+```candid
+withdraw: (Token, nat, principal) -> (WithdrawReceipt);
+```
+
+取引所に新しい注文を出します。注文が適正であった場合、注文は執行されます。
+
+```candid
+placeOrder: (Token, nat, Token, nat) -> (OrderPlacementReceipt);
+```
+
+ユーザーに発注をキャンセル出来るようにします。
+
+```candid
+cancelOrder: (OrderId) -> (CancelOrderReceipt);
+```
+
+ユーザーの持っている取引所にある特定トークン残高を要求します。
+
+```candid
+getBalance: (Token) -> (nat) query;
+```
+
+### 手数料
+
+取引から手数料を差し引くのは取引所の責任です。取引所が出金等の内部送金の手数料を支払わなければならないため重要です。
+
+## トークン取引所の具体的な検証
+
+このセクションには、取引所の中核機能の詳細な検証が含まれています。ほとんどの相互対話には複数のステップを要求され、提供されるフロントエンドを使用することで簡略化されます。取引所 Canister の機能は公開されているので、スキルのあるユーザーは ``dfx`` を使用して取引所とやり取りすることができます。
+
+### ICP のデポジット
+
+ledger Canister は独自のインターフェースを提供するため、ICP の対話において別途解決しなければならない諸問題があります。
+
+* ユーザーは ``getDepositAddress`` 関数を呼び出します。レスポンスは取引所が管理するユーザー固有のサブアカウントを表す一意のアカウント識別子を含んでいます。取引所はこのアドレスを通してデポジットするユーザーを特定することができます。
+* ユーザは取得したデポジット先アドレスに ICP を転送し、完了するのを待ちます。
+* 取引所に通知するために、ユーザーは ICP トークンの Principal で ``deposit`` を呼び出します。取引所はユーザーのサブアカウントを調べ、取引所におけるユーザーの残高を調整します。第二段階として、取引所はユーザーのサブアカウントからデフォルトのサブアカウントに資金を転送し、そこに取引所のすべての ICP を保持します。
+
+### トークンのデポジット
+
+DIP20 では、よりリッチなインターフェースで対話ができるため、トークンのデポジットがより簡単になります。
+
+* ユーザーは、 token Canister の ``approve`` 関数を呼び出します。これにより、取引所はユーザーに代わって取引所に資金を送金することができるようになります。
+* ICP のデポジットと同様に、ユーザーは取引所の ``deposit`` 機能を呼び出します。取引所は承認されたトークンを取引所に転送し、ユーザーの取引所残高を調整します。
+
+### オーダー発注
+
+取引所に資金をデポジットした後、ユーザーは注文を出すことができます。注文は2つのタプルから構成されます。 ``from: (Token1, amount1)`` と ``to: (Token2, amount2)`` です。これらの注文は取引所に追加されます。これらの注文に何が起こるかは、取引所の実装に依存します。このサンプルでは、完全に一致する注文のみを実行するシンプルな取引所を提供します。これは単なるおもちゃの取引所であり、本来の取引所の機能は完備性であることに注意してください。注意：取引所は時々貪欲になることがあります。
+
+### 資金の出金
+
+資金をデポジットすることに比べて、資金の出金は簡単です。取引所が資金を保管しているため、 ``withdraw`` のリクエストがあると、取引所はユーザーに資金を送り返します。それに応じて、取引所内の残高が調整されます。
+
+## 一般的な間違い
+
+* 同時実行。 Canister 関数が ``await`` ステートメントを持つ場合、実行がインターリーブされる可能性があります。バグを回避するために、データ構造の更新の配置を慎重に検討し、ダブルスペンス攻撃を防ぐ必要があります。
+* 浮動小数点数。より高性能な取引所では、浮動小数点に注意し、小数を制限するようにする必要があります。
+* await 後のパニック。パニックが起きると、状態がロールバックされる。これは、交換の正しさに問題を引き起こす可能性がある。
+
+
+
+////
 # DEX Sample
 
 To enable DEFI applications on the IC, canisters need to interact with token canisters and the ledger canister. This sample dapp illustrates how to facilitate these interactions.
@@ -88,3 +181,7 @@ Compared to depositing funds, withdrawing funds is simpler. Since the exchange h
 * Concurrent execution: If canister functions have ``await`` statements, it is possible that execution is interleaved. To avoid bugs, it is necessary to carefully consider the placement of data structure updates to prevent double-spend attacks.
 * Floating Points: More advanced exchanges should take care of floating points and make sure to limit decimals.
 * No panics after await: When a panic happens, the state gets rolled back. This can cause issues with the correctness of the exchange.
+
+
+
+////

--- a/modules/samples/pages/hackathon-projects.adoc
+++ b/modules/samples/pages/hackathon-projects.adoc
@@ -1,3 +1,56 @@
+= ハッカソン プロジェクト
+:description: Quick links to example code for common use-cases for your dapp
+:keywords: Internet Computer,blockchain,cryptocurrency,ICP tokens,smart contracts,cycles,wallet,software canister,developer onboarding,dapp,example,code,rust,Motoko
+:proglang: Motoko
+:IC: Internet Computer
+:company-id: DFINITY
+ifdef::env-github,env-browser[:outfilesuffix:.adoc]
+
+世界中の開発者がハッカソンに参加し Dapp やツールなど様々なプロジェクトを Internet Computer  上で構築しています。触発されるべく優勝したプロジェクトのいくつかのソースコードをご覧ください。
+
+[[dfinihack]]
+== DFINIHack
+
+ハッカソンは優れた学びの方法です。DFINITYでは外部のハッカソンに加え、社内のハッカソンも開催しています。コーディング経験の有無に関わらず、どんな分野からでも誰でも参加できます。目的は新しいユースケースの探索、開発者に提供するドキュメントやツールの評価、そしてビルダー文化を内部に浸透させることです。
+
+=== Sidekick
+Sidekick は、数行のコードで Canister スマートコントラクトを構築できる Internet Computer 上で動作する Dapp です。
+
+- https://github.com/blynn/sidekick[ GitHub のコードはこちら]
+- https://ffgig-jyaaa-aaaae-aaaoa-cai.raw.ic0.app[ Canister ライブ]
+
+=== IC Vault
+IC Vault はエンドツゥエンドの暗号化（ 言い換えると Internet Computer 内部で平文を見ることができない）により、Internet Computer を経由したデバイス間のデータの安全な同期を保証します。
+
+- https://github.com/timohanke/hack13[ GitHub のコードはこちら]
+- https://xggrc-cyaaa-aaaaj-aaasq-cai.raw.ic0.app[ Canister ライブ]
+- https://youtu.be/16xxA8EKEhE[ YouTube のプレゼンテーション]
+
+=== PrivIC
+PrivIC（「プライバシー」と発音します）は、 Internet Computer 上での ID 管理を提供します。ユーザーは、名前、生年月日、Eメール、電話番号などの属性からなる自分の ID を管理するため、直接 PrivIC アプリにアクセスするか、アプリの登録・サインイン機能で利用することができます。
+
+- https://github.com/open-ic/priv-ic[ GitHub のコードはこちら]
+
+=== DeFind
+DeFind はステーキングベースの検索エンジンです。インターネットが普及した今日、検索エンジンはウェブクローラーを使ってデータを非公開のアルゴリズムに送り込んでいます。広告主にとって、これは間違ったインセンティブになります。例えば、見えないテキストでウェブクローラーを騙したり、ボットを通じて偽のトラフィックを発生させたりするインセンティブが働くかもしれません。
+
+- https://github.com/IC-Search/ic-search[ GitHub のコードはこちら]
+- https://jbioa-siaaa-aaaai-qanfq-cai.ic0.app[ Canister ライブ]
+
+=== IC Notary
+IC Notary はある時点の文書（または任意のファイル）を保有していたことを証明できるタイムスタンプ付き公証サービスです。ユーザーはファイルを IC Notary にアップロードすることができ、また過去にアップロードされたファイルを検索・ダウンロードすることもできます。
+
+- https://github.com/jplevyak/dfnhack7[ GitHub のコードはこちら]
+- https://jbxh5-eqaaa-aaaae-qaaoq-cai.ic0.app[ Canister ライブ]
+
+=== IC Netboot
+IC Netboot は開発者が Canister から直接、仮想マシン（VM）を起動できるようにし、起動インフラの分散化と冗長化をします。さらに、zookeeper のようなアプリケーションのVMデータの予備になりえます。最後にTFTP/DHCP/iPXE のような合法的なプロトコルで Internet Computer と会話するためのコンセプトの証明となります。
+
+- https://github.com/farazshaikh/team14[ GitHub のコードはこちら]
+
+
+
+////
 = Hackathon Projects
 :description: Quick links to example code for common use-cases for your dapp
 :keywords: Internet Computer,blockchain,cryptocurrency,ICP tokens,smart contracts,cycles,wallet,software canister,developer onboarding,dapp,example,code,rust,Motoko
@@ -49,6 +102,8 @@ IC Netboot allows developers to boot a virtual machine (VM) directly from a cani
 - https://github.com/farazshaikh/team14[See code on GitHub]
 
 
+
+////
 
 
 


### PR DESCRIPTION
### modules/samples/pages/dex.adocを翻訳しました。

DEFIのサンプルを実際触ってみましたが、deposit address から取引所のアカウントに移動されず、それ以上取り扱うことが出来なかったので、理解不足しているところがあります。
特に、ICPを`deposit address` から入金すると内部移動先がユーザーものなのか取引所のものなのか不明（参考：そのデフォルトのサブアドレスに資金を移動、24行目）なので、しっくり来ておりません。リンク先のmotokoとrustのgithubもリンク切れしています。

##### 翻訳で不明・微妙な点
* 3行目 interact with token canister -> 相互に対話（インターフェイス上でのヤリトリなので相互作用より良いかと判断）60, 64, 72行目も同様
* 9行目 In combination with cheap storage -> 汎用（ありきたりなと言う意味で汎用に）
* 36行目 If the order matches an existing order -> 適正な（既発注という意味にすると意味不明になるため「現状の秩序」という意味に取りました）
* 58行目 Walkthrough -> 具体的な検証（実地調査的な意味合いを上手く表現できず）
* 60行目 Walkthrough -> 同上
* 60行目 advanced users -> スキルのあるユーザー（高度なでは日本語としておかしい？）
* 74行目 transfer funds to itself on behalf of the user -> 取引所はユーザーに代わって取引所に資金を送金（itself を取引所と判断）
* 79行目 the exchange functionality is just for completeness -> 本来の取引所の機能は完備性であること（完璧という意味でつかったもののイマイチかも？）
* 87行目 it is possible that execution is interleaved -> インターリーブ（そのままカタカナにしたが一般的かどうか）
* 89行目 No panics after await: -> await 後のパニック。（一般的な間違いをリストしているので NO を付けると間違いではなくなるのでは？）
