### PR TITLE
translated: modules/samples/pages/tokentransfer.adoc

### DIFF
--- a/modules/samples/pages/tokentransfer.adoc
+++ b/modules/samples/pages/tokentransfer.adoc
@@ -1,3 +1,59 @@
+= トークン転送 のサンプルコード
+
+トークン転送は自分のアカウントから他のアカウントにトークンを転送することができる Canister で可能になります。Ledger Canister を使用した例で示しており、金融統合や Defi Dapp を作りたいときに便利です。サンプルコードは https://github.com/dfinity/examples/tree/master/motoko/ledger-transfer[Motoko] と https://github.com/dfinity/examples/tree/master/rust/tokens_transfer[Rust] で公開されています。
+
+このサンプルコードは、転送トークン数やトークンを転送先アカウント（オプションでサブアカウントも可能）を入力に取り、また（転送に）必要なトークンがない場合などにトークン転送の Canister に成否を返すような、（トークン転送 Canister の）ひとつの中核をなす `ledger_transfer` 関数を中心に据えています。成功した場合、トランザクションの一意な識別子が返されます。この識別子は、Ledger のトランザクションの memo に保存されます。
+
+// This example demonstrates an application that transfer ICPs to its most active users.
+
+// == Prerequisites
+
+// Verify the following before running this demo:
+
+// *  You have downloaded and installed the [DFINITY Canister SDK](https://smartcontracts.org).
+
+// *  You have stopped any Internet Computer or other network process that would create a port conflict on 8000.
+
+// == Demo
+
+// 1. Follow the [Ledger: Deploying locally](https://github.com/dfinity/ic/tree/master/rs/rosetta-api/ledger_canister#deploying-locally) guide to install the ICP ledger canister locally.
+
+// 1. Open a new terminal window
+
+// 1. Build your canister
+// [source,bash]
+// ----
+//    dfx build
+// ----
+
+// 1. Figure out the address of your canister
+// [source,bash]
+// ----
+//    dfx canister call ledger_transfer canisterAddress '()'
+// ----
+
+// 1. Transfer funds to your canister
+// [source,bash]
+// ----
+//    dfx canister call ledger transfer '(record { to = blob "\08.\cf.?dz\c6\00\f4?8\a6\83B\fb\a5\b8\e6\8b\08_\02Y+w\f3\98\08\a8\d2\b5"; memo = 1; amount = record { e8s = 2_00_000_000 }; fee = record { e8s = 10_000 }; })'
+// ----
+
+// 1. Post a message as a new user
+// [source,bash]
+// ----
+//    dfx identity new homer
+//    dfx identity use homer
+//    dfx canister call ledger_transfer post "(\"Nom Nom Love Donuts\")"
+// ----
+
+// 1. Distribute rewards to users
+// [source,bash]
+// ----
+//    dfx identity use default
+//    dfx canister call ledger_transfer distributeRewards '()'
+// ----
+
+////
 = Token Transfer Sample Code
 
 Token Transfer is a canister that can transfer tokens from its account to other accounts. It is an example of a canister that uses the Ledger canister and is useful for any financial integration or defi dapps that you may like to build. Sample code is available in https://github.com/dfinity/examples/tree/master/motoko/ledger-transfer[Motoko] and https://github.com/dfinity/examples/tree/master/rust/tokens_transfer[Rust].
@@ -51,4 +107,6 @@ The sample code revolves around one core `ledger_transfer` function which takes 
 // ----
 //    dfx identity use default
 //    dfx canister call ledger_transfer distributeRewards '()'
-// ----
+//
+
+////

--- a/modules/samples/pages/tokentransfer.adoc
+++ b/modules/samples/pages/tokentransfer.adoc
@@ -1,8 +1,8 @@
 = トークン転送 のサンプルコード
 
-トークン転送は自分のアカウントから他のアカウントにトークンを転送することができる Canister で可能になります。Ledger Canister を使用した例で示しており、金融統合や Defi Dapp を作りたいときに便利です。サンプルコードは https://github.com/dfinity/examples/tree/master/motoko/ledger-transfer[Motoko] と https://github.com/dfinity/examples/tree/master/rust/tokens_transfer[Rust] で公開されています。
+Token Transfer（トークン転送）は自分のアカウントから他のアカウントにトークンを転送することができる Canister です。Ledger Canister を使用した例であり、金融統合や Defi Dapp を作りたいときに便利です。サンプルコードは https://github.com/dfinity/examples/tree/master/motoko/ledger-transfer[Motoko] と https://github.com/dfinity/examples/tree/master/rust/tokens_transfer[Rust] で公開されています。
 
-このサンプルコードは、転送トークン数やトークンを転送先アカウント（オプションでサブアカウントも可能）を入力に取り、また（転送に）必要なトークンがない場合などにトークン転送の Canister に成否を返すような、（トークン転送 Canister の）ひとつの中核をなす `ledger_transfer` 関数を中心に据えています。成功した場合、トランザクションの一意な識別子が返されます。この識別子は、Ledger のトランザクションの memo に保存されます。
+このサンプルコードは、転送トークン数や転送先アカウント（オプションでサブアカウントも可能）を入力に取り、また転送に必要なトークンがない場合などに Canister に成否を返すような、`ledger_transfer` 関数を中心に据えています。成功した場合、トランザクションの一意な識別子が返されます。この識別子は、Ledger のトランザクションの memo に保存されます。
 
 // This example demonstrates an application that transfer ICPs to its most active users.
 


### PR DESCRIPTION
# modules/samples/pages/tokentransfer.adoc を翻訳しました。

今回のページは短いのですが、抽象的な表現にとどまっているせいか難易度が高かったです。

### 不明な点と修正依頼
* 1行目　「トークン転送」としました。`token transfer` をICPの機能の一つとして見ると「トークン転送」でいいと思いますが、canisterとしてみると（3行目） `token transfer`と英語のままが良いと思われます。どっちが良いか判断が付いていません。
* 3行目　上記の関係で「canisterで可能になります」としました。原文直訳だと「canisterです」となりますが、どっちが良いか判断つきません。
* 5行目　翻訳が難しい後置修飾で複数で長いため複数括弧を設け、また少し意訳して「ような」（トークン転送の Canister に成否を返すような）と追加してみました。

おかしければ、修正をお願いします。
