### PR TITLE
translated: modules/quickstart/pages/5-quickstart.adoc

### DIFF
--- a/modules/quickstart/pages/5-quickstart.adoc
+++ b/modules/quickstart/pages/5-quickstart.adoc
@@ -1,3 +1,135 @@
+= 5. オンチェーンへデプロイ（作業時間：約1分）
+
+== 5.1 dfx でDapp をオンチェーンにデプロイする（ターミナル B ）
+
+link:developers-guide/concepts/tokens-cycles[Cycle] と `dfx` が Cycle を転送するように設定されたので `Hello` Dapp をチェーン上にデプロイする準備ができています。
+
+[source,bash]
+----
+npm install
+----
+
+[source,bash]
+----
+dfx deploy --network ic --with-cycles 1000000000000
+----
+
+`--network` オプションを Dapp をデプロイするためのネットワークエイリアスまたは URL を指定します。このオプションは Internet Computer のブロックチェーンメインネットにインストールするために必要です。`--with-cycles` は明示的に `dfx` に使用する Cycle を指定します。しない場合はデフォルトの3兆 Cycle が指定されます。
+
+成功するとターミナルは以下のように出力されます：
+
+[source,bash]
+----
+Deploying all canisters.
+Creating canisters...
+Creating canister "hello"...
+"hello" canister created on network "ic" with canister id: "5o6tz-saaaa-aaaaa-qaacq-cai"
+Creating canister "hello_assets"...
+"hello_assets" canister created on network "ic" with canister id: "5h5yf-eiaaa-aaaaa-qaada-cai"
+Building canisters...
+Building frontend...
+Installing canisters...
+Installing code for canister hello, with canister_id 5o6tz-saaaa-aaaaa-qaacq-cai
+Installing code for canister hello_assets, with canister_id 5h5yf-eiaaa-aaaaa-qaada-cai
+Authorizing our identity (default) to the asset canister...
+Uploading assets to asset canister...
+  /index.html 1/1 (472 bytes)
+  /index.html (gzip) 1/1 (314 bytes)
+  /index.js 1/1 (260215 bytes)
+  /index.js (gzip) 1/1 (87776 bytes)
+  /main.css 1/1 (484 bytes)
+  /main.css (gzip) 1/1 (263 bytes)
+  /sample-asset.txt 1/1 (24 bytes)
+  /logo.png 1/1 (25397 bytes)
+  /index.js.map 1/1 (842511 bytes)
+  /index.js.map (gzip) 1/1 (228404 bytes)
+  /index.js.LICENSE.txt 1/1 (499 bytes)
+  /index.js.LICENSE.txt (gzip) 1/1 (285 bytes)
+Deployed canisters.
+URLs:
+  Frontend:
+    hello_assets: https://5h5yf-eiaaa-aaaaa-qaada-cai.ic0.app/
+  Candid:
+    hello: https://a4gq6-oaaaa-aaaab-qaa4q-cai.raw.ic0.app/?id=5o6tz-saaaa-aaaaa-qaacq-cai
+----
+
+メッセージの一番下にあなたの Canister のフロントエンドがオンチェーンにデプロイされていることを確認できる URL が返されていることに注目してください：https://5h5yf-eiaaa-aaaaa-qaada-cai.ic0.app/
+
+上記の例のように2つの Canister で構成される `Hello` という Dapp を作成しました：
+
+a. `hello` Canister `5o6tz-saaaa-aaa-qaacq-cai`：バックエンドロジックを構成
+
+b. `hello_assets` Canister `5h5yf-eiaaa-aaa-qaada-cai`：フロントエンドのアセット（例：HTML、JS、CSS ）を構成
+
+== 5.2 ブラウザでオンチェーンのデモ用 Dapp を見てみる
+
+https://5h5yf-eiaaa-aaaaa-qaada-cai.ic0.app/ に移動し、名前を入力します。
+
+Dapp がロードされる前に、ブラウザにはすぐに次のようなメッセージが表示されます：Installing "Internet Computer Validating Service Worker" この link:https://developer.chrome.com/docs/workbox/service-worker-overview/[service worker] は IC から来たもので、ユーザーが見るウェブアプリが正しく、改ざんされていないフロントエンドであることを確認するために使用されます。一度読み込まれるとブラウザはサービスワーカーをキャッシュし、ウェブアプリはより速く読み込まれるようになります。
+
+image:quickstart/service-worker.png[Hello, everyone! greeting]
+
+サービスワーカーをロードした後 Dapp がロードされます：
+
+image:front-end-result.png[Hello, everyone! greeting]
+
+== 5.3 コマンドライン（ターミナル B ）でオンチェーンの（デモ用） Dapp をテストする
+
+Canister には `greet` というメソッド （パラメータとして文字列を受け取ります）があるので `dfx` を介してメッセージを送ることができます。
+
+[source,bash]
+----
+dfx canister --network ic call hello greet '("everyone": text)'
+----
+
+メッセージの構成に注目してください：
+
+* `dfx canister --network ic call` は IC 上の Canister を呼び出すための設定です。
+
+* `hello greet` は `hello` という名前の Canister にメッセージを送信しその `greet` メソッドを呼び出すことを意味します。これは `hello` と Canister id のマッピングがローカルの `.dfx/local/canister_ids.json` に保存されているためです。
+
+* `'("everyone": text)'` は `greet` に送るパラメータです（このパラメータは `Text` だけを入力として受け取ります）。
+
+== 結論
+
+これで Dapp をオンチェーンにデプロイできました！ チュートリアルの最後まで読むことができました。
+
+本題のチュートリアルに戻ります。 link:quickstart-intro{outfilesuffix}[quickstart イントロダクション] をご覧ください。
+
+== トラブルシューティング
+
+=== 403 エラー
+
+403エラーが表示される場合使用している ID に十分な Cycle がない可能性があります。デバッグのために以下を試してみてください。
+
+== 1. 利用していると思われる ID を確認する
+
+[source,bash]
+----
+dfx identity whoami
+----
+
+== 2. 使用している ID がオンチェーンに十分な Cycle を有していることを確認する
+
+[source,bash]
+----
+dfx wallet --network ic balance
+----
+
+== 3. ウォレット経由のプロキシを試す
+
+時々、（特に 0.9.0 より前のバージョンの `dfx` で Canister を作成した場合）あなたのウォレットが Canister のコントローラーとして設定されていることがあります。ウォレットをデプロイ指示のソースにするには、デプロイやコールコマンドに `--wallet <insert-your-wallet-id-here>` というフラグを追加してください。
+
+これがうまくいって自分の Principal をCanister のコントローラーとして追加したい場合（そうすればもう `--wallet` オプションを使う必要はありません）次のように実行します：
+
+[source, bash]
+----
+dfx canister --wallet "$(dfx identity get-wallet)" update-settings --all --add-controller "$(dfx identity get-principal)"
+----
+
+
+
+////
 = 5. Deploying On-chain (1 min)
 
 == 5.1 Deploy the Dapp On-chain via dfx (Terminal B)
@@ -127,3 +259,6 @@ If this works and you would like to add your own principal as a controller of th
 dfx canister --wallet "$(dfx identity get-wallet)" update-settings --all --add-controller "$(dfx identity get-principal)"
 ----
 
+
+
+////


### PR DESCRIPTION
# 疑問点と修正依頼点

* ６６行目　リンク先は同じアドレスにはならないので、リンクを付けるのはおかしいと思われます。
* ７６行目　６４行目に「デモ用」と説明したので、統一するため「（デモ用）」を付け加えました。
* ９５行目　少し意訳です。「結論」を「最後」に変更しました。
* １０５行目　*Confirm you are using the identity you assume are using* が分かりにくかったので意訳しました。=> 「利用していると思われる ID を確認する」
* １２１行目　*the source of the deployment instruction* の "instruction" を「指示」としましたがどうでしょうか？

以上です。レビューお願いします。
