### PR TITLE
traslated: modules/developers-guide/pages/cli-reference/dfx-generate.…

### DIFF
--- a/modules/developers-guide/pages/cli-reference/dfx-generate.adoc
+++ b/modules/developers-guide/pages/cli-reference/dfx-generate.adoc
@@ -1,5 +1,111 @@
 = dfx generate
 
+サポートされているプログラミング言語用の Canister 型宣言を生成するには、 `+dfx generate+` コマンドを使用します。
+`+dfx generate+` は、現在、4つの言語（ Motoko、Candid、JavaScript、TypeScript ）をサポートしています。
+
+このコマンドを使うと、プロジェクトの `+dfx.json+` 設定ファイルで定義されているすべての Canister または特定の Canister の型宣言を生成することができます。
+
+このコマンドはプロジェクトのディレクトリ構造内からのみ実行出来ることに注意してください。
+例えば、プロジェクト名が `+hello_world+` の場合、現在の作業ディレクトリは `+hello_world+` のトップレベルのプロジェクトディレクトリかそのサブディレクトリのいずれかである必要があります。
+
+`+dfx generate+` コマンドは、`+dfx.json+` 設定ファイル内、 Canister の `+declarations+` セクション下の設定を探しにいきます。
+
+== 基本的な利用法
+
+[source,bash]
+----
+dfx generate [canister_name]
+----
+
+== フラグ
+
+`+dfx generate+` コマンドでは、以下のオプションフラグを使用することができます。
+
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|フラグ |説明
+
+|`+-h+`, `+--help+` |利用情報を表示します。
+
+|`+-V+`, `+--version+` |バージョン情報を表示します。
+|===
+
+== 引数
+
+`+dfx generate+` コマンドには以下の引数を指定することができます。
+
+[width="100%",cols="<36%,<64%",options="header"]
+|===
+
+|引数 |説明
+
+|`+canister_name+` |型宣言を生成するための Canister の名前を指定します。
+この Canister 名はプロジェクトの `+dfx.json+` 設定ファイルの `+canisters+` セクションで設定した名前と少なくとも1つは一致している必要があります。
+この引数を指定しない場合、`+dfx generate+` は `+dfx.json+` で宣言されたすべての Canister に対して型宣言を生成します。
+
+|===
+
+== 設定
+
+`+dfx generate+` の動作は `+dfx.json+` 設定ファイルによって制御されます。
+`+dfx.json+` → `+canisters+` → `+<canister_name>+` の下に、 `+declarations+` セクションを追加することができます。
+このセクションでは、以下のフィールドを指定することができます。
+
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|フィールド|説明
+
+|`+output+` |Canister の宣言を配置するディレクトリで、デフォルトは `+src/declarations/<canister_name>+` です。
+
+|`+bindings+` |型宣言を生成するための言語のリストで、オプションは `+"js", "ts", "did", "mo "+` です。デフォルトは `+["js", "ts", "did"]+` です。
+
+|`+env_override+` |`+src/dfx/assets/language_bindings/canister.js+` テンプレート内の `+process.env.{canister_name_uppercase}_CANISTER_ID+` を置き換えるための文字列です。
+
+|===
+
+`+dfx generate+` からの出力。
+
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|言語 |ファイル
+
+|`+JavaScript(js)+` |`+index.js+` と `+<canister_name>.did.js+`
+
+|`+TypeScript(ts)+` |`+<canister_name>.did.ts+`
+
+|`+Candid(did)+` |`+<canister_name>.did+`
+
+|`+Motoko(mo)+` |`+<canister_name>.mo+`
+|===
+
+== 例
+
+[source,json]
+----
+include::example$sample-generate-dfx.json[]
+----
+
+ファイルシステム上のプログラムのファイル名とパスは設定ファイル `+dfx.json+` で指定された情報と一致している必要があることに注意してください。
+
+この例では、`+hello_world+` Canister そのものは Motoko で書かれています。`+declarations+` セクションでは、4つの言語の型宣言が生成、保存される `+src/declarations/+` が指定されています。
+
+[source,bash]
+----
+dfx generate hello_world
+----
+
+`+dfx.json+` には Canister が一つしかないので、引数なしで `+dfx generate+` を呼び出すと、上記のコマンドと同じ効果が得られます。 もし、`+dfx.json+` に複数の Canister が定義されていた場合、定義されているすべての Canister の型宣言を生成することになります。
+
+[source,bash]
+----
+dfx generate
+----
+
+
+
+////
+= dfx generate
+
 Use the `+dfx generate+` command to generate canister type declarations for supported programming languages.
 Currently, `+dfx generate+` supports four languages: Motoko, Candid, JavaScript, and TypeScript.
 
@@ -101,3 +207,7 @@ Since there is only one canister in `+dfx.json+`, calling `+dfx generate+` witho
 ----
 dfx generate
 ----
+
+
+
+////


### PR DESCRIPTION
# 疑問点と修正依頼点

* １１行目　"The dfx generate command looks for the configuration under the declarations section of a canister in the dfx.json configuration file."を「探しにいきます」としましたが、"refer to"ではないとしても「参照しにいきます」のほうがしっくりきますがどうでしょうか？
* ６６行目　体言止めにしました。

以上です。レビューお願いします。
