### PR TITLE
traslated: modules/developers-guide/pages/cli-reference/dfx-start.adoc

### DIFF
--- a/modules/developers-guide/pages/cli-reference/dfx-start.adoc
+++ b/modules/developers-guide/pages/cli-reference/dfx-start.adoc
@@ -1,5 +1,79 @@
 = dfx start
 
+`+dfx start+` コマンドを使用すると、現在のプロジェクトのローカル Canister 実行環境とWeb サーバープロセスを起動することができます。
+このコマンドは、開発中のアプリをテストするために、ローカルの Canister 実行環境に Canister をデプロイすることを可能にします。
+
+このコマンドは、プロジェクトのディレクトリ構造内からしか実行できないことに注意してください。
+例えば、プロジェクト名が `+hello_world+` の場合、現在の作業ディレクトリは `+hello_world+` のトップレベルのプロジェクトディレクトリかそのサブディレクトリのいずれかである必要があります。
+
+== 基本的な利用法
+
+[source,bash]
+----
+dfx start [option] [flag]
+----
+
+== フラグ
+
+`+dfx start+` コマンドでは、以下のオプションフラグを使用することができます。
+
+[width="100%",cols="<32%,<68%",options="header"]
+|===
+|フラグ |説明
+|`+--background+` |ローカル Canister の実行環境と Web サーバープロセスをバックグラウンドで起動し、応答を待ってシェルに戻ります。
+|`+--clean+` |プロジェクト・キャッシュからチェックポイントを削除して、クリーンな状態でローカル Canister 実行環境と Web サーバープロセスを開始します。
+このフラグは、トラブルシューティングやデバッグの際に、プロジェクト・キャッシュを新しい状態に設定するために使用できます。
+
+|`+-h+`, `+--help+` |利用情報を表示します。
+|`+-V+`, `+--version+` |バージョン情報を表示します。
+|===
+
+== オプション
+
+`+dfx start+` コマンドで以下のオプションを使用することができます。
+
+[width="100%",cols="<32%,<68%",options="header",]
+|===
+|オプション|説明
+|`+--host host+` |フロントエンドをバインドするホストインターフェイスの IP アドレスとポート番号を指定します。デフォルトは `127.0.0.1:8000` です。
+|===
+
+== 例
+
+以下のコマンドを実行することで、現在のシェルでローカル Canister 実行環境とWeb サーバープロセスを起動することができます：
+
+[source,bash]
+----
+dfx start
+----
+
+現在のシェルでローカル Canister 実行環境を起動した場合、追加のコマンドを実行するために新しい ターミナルシェルを開く必要があります。
+または、以下のコマンドを実行して、ローカル Canister 実行環境をバックグラウンドで起動することもできます：
+
+[source,bash]
+----
+dfx start --background
+----
+
+ただし、ローカル Canister 実行環境をバックグラウンドで実行している場合は、`+dfx+` 実行環境をアンインストールまたは再インストールする前に、以下のコマンドを実行してローカル Canister 実行環境を必ず停止してください：
+
+[source,bash]
+----
+dfx stop
+----
+
+以下のコマンドを実行することで、`+dfx+` で起動したローカル Canister 実行環境プロセスの現在のプロセス ID（ `+pid+` ）を確認することができます：
+
+[source,bash]
+----
+more .dfx/pid
+----
+
+
+
+////
+= dfx start
+
 Use the `+dfx start+` command to start a local canister execution environment and web server processes for the current project.
 This command enables you to deploy canisters to the local canister execution environment to test your dapps during development.
 
@@ -70,3 +144,7 @@ You can view the current process identifier (`+pid+`) for  the local canister ex
 ----
 more .dfx/pid
 ----
+
+
+
+////


### PR DESCRIPTION
# 疑問点・修正依頼点
* 50行目　ターミナルシェル　原文をそのまま訳しましたが、調べたところ、ターミナルとシェルは別物なのでターミナル（シェル）のほうがよいかもしれません。

レビューお願いします。



