### PR TITLE
traslated: modules/security-best-practices/pages/general-security-bes…

### DIFF
--- a/modules/security-best-practices/pages/general-security-best-practices.adoc
+++ b/modules/security-best-practices/pages/general-security-best-practices.adoc
@@ -1,3 +1,93 @@
+= 一般的なベストプラクティス
+
+== セキュリティが妥当であればクエリレスポンスを認証します
+
+=== セキュリティの心配事
+
+link:https://smartcontracts.org/docs/interface-spec/index.html#http-interface[クエリコール] （アップデートコールとは対照的に）へのレスポンスは、Canister / Subnet（サブネット）によって閾値署名されません。したがって、悪意のある単一のレプリカまたはバウンダリノードがデータを変更し、その真正性を侵害する可能性があります。これは、アップデートコールがクエリコールへのレスポンスに依存している場合、特に危険なことです。
+
+=== 推奨
+
+- 真正性の保証が必要なセキュリティ関連のクエリレスポンスデータ（これは各 Dapp について評価する必要があります）は、すべて認証変数を使用して IC によって認証されるべきです。link:https://github.com/dfinity/cdk-rs/tree/main/src/ic-certified-map[certified-map] などの既存のデータ構造の利用を検討してください。データの認証は、フロントエンドで検証する必要があります。
+- あるいは、これらの呼び出しは呼び出し側でアップデートコールとして発行されなければなりませんが（例えば agent-js で）、「数秒かかる」というパフォーマンスに影響を与えます。すべてのクエリは呼び出し側でアップデートとして発行できることに注意してください。
+- サンプルは link:https://github.com/dfinity/internet-identity/blob/b29a6f68bbe5a49d048e12bc7a3263a9f43d080b/src/internet_identity/src/main.rs#L775-L808[Internet Identity] 、link:https://github.com/dfinity/nns-dapp/blob/372c3562127d70c2fde059bc9c268e8ae858583e/rs/src/assets.rs#L121-L145[NNS dApp] や link:https://github.com/dfinity/internet-identity/blob/main/src/internet_identity/src/signature_map.rs[Internet Identityの Canister 署名実装] などの資産認証の場合です。
+
+== Internet Computer に特有ではないもの
+
+このセクションのベストプラクティスは、非常に一般的なものであり、Internet Computer に特化したものではありません。このリストは決して完全なものではなく、過去に問題になった非常に具体的な懸念事項をいくつか挙げているに過ぎません。
+
+=== 脆弱性が知られているサードパーティ製コンポーネントを使用しない
+
+==== セキュリティの心配事
+
+脆弱で古いコンポーネントを使用することは、link:https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/[大きなセキュリティリスク] です。
+
+==== 推奨
+
+- サードパーティ製コンポーネントは既知の脆弱性のデータベースと定期的に照合します。
+- Rust： link:https://crates.io/crates/cargo-audit[cargo audit] を使用します。
+- JavaScript / NPM： link:https://docs.npmjs.com/cli/v8/commands/npm-audit[npm audit] を使用します。
+- これはビルドプロセスに統合されるべき話ですが、既知の脆弱性がある場合、ビルドは失敗させるべきです。
+- メンテナンスされておらず、信頼できない可能性のあるリポジトリのフォーク版を使わないでください。
+- 広く使われておらず、十分な（理想的には第三者による）レビューを受けていない可能性のあるサードパーティコンポーネントの使用は避けてください。
+- 使用しているコンポーネントのバージョンを固定し、自動的に破損したアップデートに切り替わらないようにします。
+
+=== 暗号を自分で実装しない
+
+==== セキュリティの心配事
+
+暗号アルゴリズムの実装ではミスが発生しやすく、セキュリティバグが発生しやすいです。
+
+==== 推奨
+
+- オープンソースで、多くの人がレビューしているよく知られたライブラリを使用します。例えば、JavaScript では https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API[Web Crypto API] 、Rust では link:https://crates.io/crates/sha256[sha256] などの crate を使用します。
+
+=== 安全な暗号化スキームを使用する
+
+==== セキュリティの心配事
+
+暗号スキームには、解読されて利用不可なもの（古い TLS バージョン、MD5、SHA1、DES など）や、新しすぎてまだ適切に研究されていないものがあります。これらを使用すると、セキュリティ上の問題が発生します。
+
+==== 推奨
+
+暗号を使用する必要がある場合は、解読されておらず、既知の問題がない暗号スキームのみを使用することです。NIST や IETF などで標準化されたアルゴリズムを使用するのが理想的です。
+
+参照：
+
+- link:https://owasp.org/Top10/A02_2021-Cryptographic_Failures/[OWASP Cryptographic Failures（暗号の不具合）]
+
+=== コードをテストする
+
+==== セキュリティの心配事
+
+テストのカバー範囲が小さいと、コードの変更が難しくなり、正しさやセキュリティの特性に違反し、バグが発生する可能性があるためリスクが高いです。レビュー（およびセキュリティレビュー）において、対応するテストがない場合、正しさやセキュリティ特性を検証することは困難です。
+
+==== 推奨
+
+Cainister の実装とフロントエンドのコードに対して、特にセキュリティ関連のプロパティと不変条件に対するテストを書きます。
+
+- link:https://mmapped.blog/posts/01-effective-rust-canisters.html[Effective Rust Canisters] の中で特に： link:https://mmapped.blog/posts/01-effective-rust-canisters.html#test-upgrades[test upgrades（テストアップグレード）] 、link:https://mmapped.blog/posts/01-effective-rust-canisters.html#target-independent[make code target-independent（コードをターゲット非依存にする）]
+- link:rust-canister-development-security-best-practices#test-your-canister-code[ Test your canister code even in presence of System API calls（System API コールがある場合でも Canister コードをテストする）] も参照してください。
+- link:https://docs.dfinity.systems/dfinity/spec/meta/rust.html#_tests[DFINITY Rust guidelines on testing（テストに関する DFINITY Rust のガイドライン）] を検討してください。
+- wasm レベルのユニットテストには、link:https://github.com/kritzcreek/motoko-matchers[Motoko Matchers] の利用を検討してください。
+- Motoko レベルのユニットテストには、link:https://kritzcreek.github.io/motoko-matchers/Canister.html[the Canister Module] を検討してみてください。link:https://github.com/dfinity/motoko-base/blob/master/test/resultTest.mo[ここ] と link:https://github.com/dfinity/motoko-base/blob/master/test/textTest.mo[ここ] にはテスト例もあります。例として、link:https://github.com/dfinity/invoice-canister[invoice canister] のエンドツーエンドテストとユニットテストもご覧ください。
+- 長期的なテストシナリオについては、link:https://github.com/matthewhammer/motoko-bigtest[Motoko BigTest] を検討してください。
+
+=== 本番環境でのテストコードや開発コードの使用を避ける
+
+==== セキュリティの心配事
+
+開発用やテスト用のセットアップにしか使われていないコードパスを本番用のコードに含めるのは危険です。何か問題が発生した場合（時に発生します！）、本番環境にセキュリティバグを持ち込む可能性があるからです。
+
+例えば、認証を確認するための公開鍵が信頼されていないソースから取得された問題の報告があります。
+
+==== 推奨
+
+可能な限り、プロダクションコードにテストコードや開発コードが含まれないようにします。
+
+
+
+////
 = General Best Practices
 
 == Certify query responses if they are relevant for security
@@ -84,3 +174,7 @@ For example, we have seen issues where the public key to verify certification wa
 ==== Recommendation
 
 Avoid test and dev code in production code whenever possible.
+
+
+
+////

--- a/modules/security-best-practices/pages/general-security-best-practices.adoc
+++ b/modules/security-best-practices/pages/general-security-best-practices.adoc
@@ -2,15 +2,15 @@
 
 == セキュリティが妥当であればクエリレスポンスを認証します
 
-=== セキュリティの心配事
+=== セキュリティ上の懸念事項
 
-link:https://smartcontracts.org/docs/interface-spec/index.html#http-interface[クエリコール] （アップデートコールとは対照的に）へのレスポンスは、Canister / Subnet（サブネット）によって閾値署名されません。したがって、悪意のある単一のレプリカまたはバウンダリノードがデータを変更し、その真正性を侵害する可能性があります。これは、アップデートコールがクエリコールへのレスポンスに依存している場合、特に危険なことです。
+link:https://smartcontracts.org/docs/interface-spec/index.html#http-interface[クエリコール] へのレスポンスは（アップデートコールとは対照的に）、Canister / Subnet（サブネット）によって閾値署名されません。したがって、悪意のある単一のレプリカまたはバウンダリノードがデータを変更し、その真正性を侵害する可能性があります。これは、アップデートコールがクエリコールへのレスポンスに依存している場合、特に危険なことです。
 
 === 推奨
 
-- 真正性の保証が必要なセキュリティ関連のクエリレスポンスデータ（これは各 Dapp について評価する必要があります）は、すべて認証変数を使用して IC によって認証されるべきです。link:https://github.com/dfinity/cdk-rs/tree/main/src/ic-certified-map[certified-map] などの既存のデータ構造の利用を検討してください。データの認証は、フロントエンドで検証する必要があります。
-- あるいは、これらの呼び出しは呼び出し側でアップデートコールとして発行されなければなりませんが（例えば agent-js で）、「数秒かかる」というパフォーマンスに影響を与えます。すべてのクエリは呼び出し側でアップデートとして発行できることに注意してください。
-- サンプルは link:https://github.com/dfinity/internet-identity/blob/b29a6f68bbe5a49d048e12bc7a3263a9f43d080b/src/internet_identity/src/main.rs#L775-L808[Internet Identity] 、link:https://github.com/dfinity/nns-dapp/blob/372c3562127d70c2fde059bc9c268e8ae858583e/rs/src/assets.rs#L121-L145[NNS dApp] や link:https://github.com/dfinity/internet-identity/blob/main/src/internet_identity/src/signature_map.rs[Internet Identityの Canister 署名実装] などの資産認証の場合です。
+- 真正性の保証が必要なセキュリティ関連のクエリレスポンスデータ（これは各 Dapp について評価する必要があります）は、すべて認証変数（certified variable）を使用して IC によって認証されるべきです。link:https://github.com/dfinity/cdk-rs/tree/main/src/ic-certified-map[certified-map] などの既存のデータ構造の利用を検討してください。データの認証は、フロントエンドで検証する必要があります。
+- あるいは、これらの呼び出しは呼び出し側でアップデートコールとして発行されなければなりませんが（例えば agent-js で）、これはパフォーマンスに影響を与えます（具体的には、数秒かかります）。すべてのクエリは呼び出し側でアップデート（コール）として発行できることに注意してください。
+- サンプルは link:https://github.com/dfinity/internet-identity/blob/b29a6f68bbe5a49d048e12bc7a3263a9f43d080b/src/internet_identity/src/main.rs#L775-L808[Internet Identity] 、link:https://github.com/dfinity/nns-dapp/blob/372c3562127d70c2fde059bc9c268e8ae858583e/rs/src/assets.rs#L121-L145[NNS dApp] や link:https://github.com/dfinity/internet-identity/blob/main/src/internet_identity/src/signature_map.rs[Internet Identityの Canister 署名実装] などのアセット認証です。
 
 == Internet Computer に特有ではないもの
 
@@ -18,7 +18,7 @@ link:https://smartcontracts.org/docs/interface-spec/index.html#http-interface[�
 
 === 脆弱性が知られているサードパーティ製コンポーネントを使用しない
 
-==== セキュリティの心配事
+==== セキュリティ上の懸念事項
 
 脆弱で古いコンポーネントを使用することは、link:https://owasp.org/Top10/A06_2021-Vulnerable_and_Outdated_Components/[大きなセキュリティリスク] です。
 
@@ -34,17 +34,17 @@ link:https://smartcontracts.org/docs/interface-spec/index.html#http-interface[�
 
 === 暗号を自分で実装しない
 
-==== セキュリティの心配事
+==== セキュリティ上の懸念事項
 
 暗号アルゴリズムの実装ではミスが発生しやすく、セキュリティバグが発生しやすいです。
 
 ==== 推奨
 
-- オープンソースで、多くの人がレビューしているよく知られたライブラリを使用します。例えば、JavaScript では https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API[Web Crypto API] 、Rust では link:https://crates.io/crates/sha256[sha256] などの crate を使用します。
+- オープンソースで、多くの人がレビューしているよく知られたライブラリを使用します。例えば、JavaScript では https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API[Web Crypto API] 、Rust では link:https://crates.io/crates/sha256[sha256] などの crate を使用しましょう。
 
 === 安全な暗号化スキームを使用する
 
-==== セキュリティの心配事
+==== セキュリティ上の懸念事項
 
 暗号スキームには、解読されて利用不可なもの（古い TLS バージョン、MD5、SHA1、DES など）や、新しすぎてまだ適切に研究されていないものがあります。これらを使用すると、セキュリティ上の問題が発生します。
 
@@ -58,13 +58,13 @@ link:https://smartcontracts.org/docs/interface-spec/index.html#http-interface[�
 
 === コードをテストする
 
-==== セキュリティの心配事
+==== セキュリティ上の懸念事項
 
 テストのカバー範囲が小さいと、コードの変更が難しくなり、正しさやセキュリティの特性に違反し、バグが発生する可能性があるためリスクが高いです。レビュー（およびセキュリティレビュー）において、対応するテストがない場合、正しさやセキュリティ特性を検証することは困難です。
 
 ==== 推奨
 
-Cainister の実装とフロントエンドのコードに対して、特にセキュリティ関連のプロパティと不変条件に対するテストを書きます。
+Cainister の実装とフロントエンドのコードに対して、特にセキュリティ関連のプロパティと不変条件に対するテストを書きましょう。
 
 - link:https://mmapped.blog/posts/01-effective-rust-canisters.html[Effective Rust Canisters] の中で特に： link:https://mmapped.blog/posts/01-effective-rust-canisters.html#test-upgrades[test upgrades（テストアップグレード）] 、link:https://mmapped.blog/posts/01-effective-rust-canisters.html#target-independent[make code target-independent（コードをターゲット非依存にする）]
 - link:rust-canister-development-security-best-practices#test-your-canister-code[ Test your canister code even in presence of System API calls（System API コールがある場合でも Canister コードをテストする）] も参照してください。
@@ -75,7 +75,7 @@ Cainister の実装とフロントエンドのコードに対して、特にセ�
 
 === 本番環境でのテストコードや開発コードの使用を避ける
 
-==== セキュリティの心配事
+==== セキュリティ上の懸念事項
 
 開発用やテスト用のセットアップにしか使われていないコードパスを本番用のコードに含めるのは危険です。何か問題が発生した場合（時に発生します！）、本番環境にセキュリティバグを持ち込む可能性があるからです。
 
@@ -83,7 +83,7 @@ Cainister の実装とフロントエンドのコードに対して、特にセ�
 
 ==== 推奨
 
-可能な限り、プロダクションコードにテストコードや開発コードが含まれないようにします。
+可能な限り、プロダクションコードにテストコードや開発コードが含まれないようにしましょう。
 
 
 


### PR DESCRIPTION
# 疑問点と修正依頼点

* 11行目　certified variablesを認証変数と訳しましたが妥当でしょうか？
* 30行目　"This should be integrated into the build process"のthisが何を指しているのか確信持てず、「脆弱で古いコンポーネントを使用すること」（23行目）と勝手に判断しました。妥当でしょうか？また今読むと、「ビルドを失敗させるべき」は「ビルドは失敗するでしょう」くらいのほうが良いかもしれません。

リンク先が英文の場合、リンクタイトルは原文のままとしておりましたが、あまりにリンクが多いと英文の羅列になるので（69行目以降）タイトル訳を括弧にして付けております。すこし読み難いかもしれません。

以上です。
よろしくおねがいします。
